### PR TITLE
Enable custom executable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,45 +30,53 @@ exports.default = {
         var _this = this;
 
         return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee() {
-            var puppeteerArgs, page;
+            var launchArgs, noSandboxArgs, userArgs, params, executablePath, page;
             return _regenerator2.default.wrap(function _callee$(_context) {
                 while (1) {
                     switch (_context.prev = _context.next) {
                         case 0:
                             if (_this.browser) {
-                                _context.next = 6;
+                                _context.next = 7;
                                 break;
                             }
 
-                            puppeteerArgs = [];
+                            launchArgs = {
+                                timeout: 10000
+                            };
+                            noSandboxArgs = ['--no-sandbox', '--disable-setuid-sandbox'];
 
 
-                            if (browserName === "no_sandbox") {
-                                console.log('Using puppeteer without sandbox!');
-                                puppeteerArgs = ['--no-sandbox', '--disable-setuid-sandbox'];
+                            if (browserName === 'no_sandbox') launchArgs.args = noSandboxArgs;else if (browserName.indexOf('?') !== -1) {
+                                userArgs = browserName.split('?');
+                                params = userArgs[0];
+
+
+                                if (params === 'no_sandbox') launchArgs.args = noSandboxArgs;
+
+                                executablePath = userArgs[1];
+
+
+                                if (executablePath.length > 0) launchArgs.executablePath = executablePath;
                             }
-                            _context.next = 5;
-                            return _puppeteer2.default.launch({
-                                timeout: 10000,
-                                args: puppeteerArgs
-                            });
-
-                        case 5:
-                            _this.browser = _context.sent;
+                            _context.next = 6;
+                            return _puppeteer2.default.launch(launchArgs);
 
                         case 6:
-                            _context.next = 8;
+                            _this.browser = _context.sent;
+
+                        case 7:
+                            _context.next = 9;
                             return _this.browser.newPage();
 
-                        case 8:
+                        case 9:
                             page = _context.sent;
-                            _context.next = 11;
+                            _context.next = 12;
                             return page.goto(pageUrl);
 
-                        case 11:
+                        case 12:
                             _this.openedPages[id] = page;
 
-                        case 12:
+                        case 13:
                         case 'end':
                             return _context.stop();
                     }
@@ -80,19 +88,15 @@ exports.default = {
         var _this2 = this;
 
         return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee2() {
-            var page;
             return _regenerator2.default.wrap(function _callee2$(_context2) {
                 while (1) {
                     switch (_context2.prev = _context2.next) {
                         case 0:
-                            page = _this2.openedPages[id];
-
-
                             delete _this2.openedPages[id];
-                            _context2.next = 4;
-                            return page.close();
+                            _context2.next = 3;
+                            return _this2.browser.close();
 
-                        case 4:
+                        case 3:
                         case 'end':
                             return _context2.stop();
                     }

--- a/src/index.js
+++ b/src/index.js
@@ -8,25 +8,29 @@ export default {
 
     openedPages: {},
 
-
     // Required - must be implemented
     // Browser control
     async openBrowser (id, pageUrl, browserName) {
-
         if (!this.browser) {
-            let puppeteerArgs = [];
+            const launchArgs = {
+                timeout: 10000
+            };
 
-            if (browserName === 'no_sandbox') {
-                puppeteerArgs = [
-                    '--no-sandbox',
-                    '--disable-setuid-sandbox'
-                ];
+            const noSandboxArgs = ['--no-sandbox', '--disable-setuid-sandbox'];
+
+            if (browserName === 'no_sandbox') launchArgs.args = noSandboxArgs;
+            else if (browserName.indexOf('?') !== -1) {
+                const userArgs = browserName.split('?');
+                const params = userArgs[0];
+
+                if (params === 'no_sandbox') launchArgs.args = noSandboxArgs;
+
+                const executablePath = userArgs[1];
+
+                if (executablePath.length > 0)
+                    launchArgs.executablePath = executablePath;
             }
-            this.browser = await puppeteer.launch({
-                timeout: 10000,
-                args: puppeteerArgs
-            });
-
+            this.browser = await puppeteer.launch(launchArgs);
         }
 
         const page = await this.browser.newPage();
@@ -39,7 +43,6 @@ export default {
         delete this.openedPages[id];
         await this.browser.close();
     },
-
 
     async isValidBrowserName () {
         return true;


### PR DESCRIPTION
solves issue https://github.com/jdobosz/testcafe-browser-provider-puppeteer/issues/7

it is a simple workaround, doesn't break the `no_sandbox` parameter:

```javascript
runner
  .browsers(['puppeteer:no_sandbox?/usr/bin/chromium-browser'])
  ...

runner
  .browsers(['puppeteer:?/usr/bin/chromium-browser'])
  ...
```