### PR TITLE
Add waitUntil option to page.goto

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default {
           await page.emulate(device);
         }
 
-        await page.goto(pageUrl);
+        await page.goto(pageUrl, { waitUntil: 'networkidle0' });
         this.openedPages[id] = page;
     },
 


### PR DESCRIPTION
Hello @jdobosz 👋

I would like to introduce [`waitUntil`](https://pptr.dev/#?product=Puppeteer&version=v5.2.1&show=api-pagegotourl-options) option to `page.goto`.
I might be useful during visual regression testing, especially in case of having background images applied with CSS.

